### PR TITLE
Add per-transformation auto-copy control

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -61,7 +61,7 @@ Panel {
   readonly property color accent: Color.accent
   readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
 
-  // [{ name, prompt }], as the script hands them over.
+  // [{ name, prompt, autoCopy }], as the script hands them over.
   property var transformations: []
   property int selectedIndex: 0
   property string inputText: ""
@@ -69,6 +69,9 @@ Panel {
   property string errorText: ""
   property bool busy: false
   property bool copied: false
+  // Captured at the start of a run, so editing settings while it is running
+  // cannot change what happens to that answer.
+  property bool runningAutoCopy: true
   // A result that landed while the panel was closed, so the bar can say so.
   property bool resultWaiting: false
   // Set while a stop is on its way, so the empty answer that follows is read
@@ -142,6 +145,7 @@ Panel {
     outputText = ""
     copied = false
     cancelled = false
+    runningAutoCopy = currentTransformation.autoCopy !== false
     busy = true
     runProc.request = JSON.stringify({
       text: inputText,
@@ -293,7 +297,8 @@ Panel {
     draft.clear()
     for (var i = 0; i < transformations.length; i++) {
       draft.append({ name: String(transformations[i].name),
-                     prompt: String(transformations[i].prompt) })
+                     prompt: String(transformations[i].prompt),
+                     autoCopy: transformations[i].autoCopy !== false })
     }
     settingsOpen = true
 
@@ -305,8 +310,8 @@ Panel {
 
   function updateDraft(index, field, value) {
     if (index < 0 || index >= draft.count) return
-    if (String(draft.get(index)[field]) === String(value)) return
-    draft.setProperty(index, field, String(value))
+    if (draft.get(index)[field] === value) return
+    draft.setProperty(index, field, value)
   }
 
   // Drag the settings window to whatever just took the keyboard. Tabbing to a
@@ -329,7 +334,7 @@ Panel {
   }
 
   function addDraft() {
-    draft.append({ name: "New transformation", prompt: "" })
+    draft.append({ name: "New transformation", prompt: "", autoCopy: true })
 
     // The row does not exist yet: appending to the model builds the delegate
     // after this returns. So scrolling to it and naming it have to wait a
@@ -355,7 +360,8 @@ Panel {
     var list = []
     for (var i = 0; i < draft.count; i++) {
       var item = draft.get(i)
-      list.push({ name: String(item.name), prompt: String(item.prompt) })
+      list.push({ name: String(item.name), prompt: String(item.prompt),
+                  autoCopy: item.autoCopy !== false })
     }
     saveProc.request = JSON.stringify({ transformations: list })
     saveProc.stdinEnabled = true
@@ -475,7 +481,7 @@ Panel {
             replaceTarget = root.replaceWindow
             root.replaceWindow = ""
             replace = true
-          } else {
+          } else if (root.runningAutoCopy) {
             // Straight onto the clipboard. Transforming text is a step on the
             // way to pasting it somewhere else, so making that a second click
             // only adds a click. The copy button stays for a second helping.
@@ -485,6 +491,12 @@ Panel {
             // the part you cannot see. The text itself stays out of it: a
             // notification can end up on a lock screen.
             root.notify("Text Transform", "Transformed and copied to your clipboard")
+          } else {
+            // Questions often need reading rather than pasting. Keep the
+            // answer in the panel and never put it on the clipboard. Unlike
+            // the copy notification, this deliberately carries the result so
+            // someone who has walked away can read the answer there.
+            root.notify("Text Transform", root.plain(root.outputText))
           }
         } else {
           root.errorText = String((payload && payload.error) || "Something went wrong")
@@ -568,7 +580,7 @@ Panel {
         // agent is not ready the panel stays open saying why, exactly as it
         // would after a manual paste.
         if (go && root.canRun) {
-          root.closeWhenDone = true
+          root.closeWhenDone = root.currentTransformation.autoCopy !== false
           root.runTransform()
         }
       }
@@ -1365,6 +1377,7 @@ Panel {
                 required property int index
                 required property string name
                 required property string prompt
+                required property bool autoCopy
 
                 // So addDraft can put the cursor in the row it just made.
                 property alias nameField: nameField
@@ -1391,7 +1404,7 @@ Panel {
                     TextField {
                       id: nameField
                       anchors.left: parent.left
-                      anchors.right: removeButton.left
+                      anchors.right: autoCopyButton.left
                       anchors.rightMargin: Style.space(6)
                       anchors.verticalCenter: parent.verticalCenter
                       text: draftRow.name
@@ -1405,6 +1418,39 @@ Panel {
                       onTextChanged: root.updateDraft(draftRow.index, "name", text)
                       onActiveFocusChanged: {
                         if (activeFocus) root.revealInDrafts(nameField, 0, height)
+                      }
+                    }
+
+                    PanelActionButton {
+                      id: autoCopyButton
+                      anchors.right: removeButton.left
+                      anchors.rightMargin: Style.space(6)
+                      anchors.verticalCenter: parent.verticalCenter
+                      focusable: true
+                      // A copy glyph names the action itself; the slash only
+                      // changes whether that action happens automatically.
+                      iconText: root.iconCopy
+                      tooltipText: draftRow.autoCopy
+                        ? "Copy result to clipboard automatically: on"
+                        : "Copy result to clipboard automatically: off"
+                      foreground: draftRow.autoCopy ? root.accent : root.foreground
+                      hoverColor: root.accent
+                      fontFamily: root.fontFamily
+                      onClicked: root.updateDraft(draftRow.index, "autoCopy", !draftRow.autoCopy)
+                      onActiveFocusChanged: {
+                        if (activeFocus) root.revealInDrafts(autoCopyButton, 0, height)
+                      }
+
+                      // Off is a preference, not an error, so its slash uses
+                      // the normal foreground rather than an urgent colour.
+                      Rectangle {
+                        visible: !draftRow.autoCopy
+                        anchors.centerIn: parent
+                        width: parent.width * 1.1
+                        height: Math.max(1, Style.space(1))
+                        rotation: -45
+                        color: root.foreground
+                        radius: height / 2
                       }
                     }
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Type or paste into the top box, choose a transformation, and press the arrow (or
 
 Three small buttons do the rest. The one in the input box pastes your clipboard in. In the output box, the up arrow sends the answer back to the top so you can run it through another transformation (shortening something twice is a different thing from asking for it very short once), and the other copies it again.
 
-A transform takes a few seconds. You do not have to sit and watch it: close the panel and carry on, and the arrows in the bar stay lit while the agent works. When the answer lands you get a notification and the text is waiting in the panel next time you open it. The notification says only that it finished and that it is on your clipboard; your text stays out of it, because notifications end up on lock screens.
+A transform takes a few seconds. You do not have to sit and watch it: close the panel and carry on, and the arrows in the bar stay lit while the agent works. When the answer lands you get a notification and the text is waiting in the panel next time you open it. With automatic copy on, the notification says only that it finished and that it is on your clipboard, because notifications end up on lock screens. With automatic copy off, the notification contains the answer so you can read it without reopening the panel.
 
 If it takes too long, the arrow becomes a stop button, and Ctrl+Enter does the same. Stopping kills the agent rather than just hiding the spinner: an agent left thinking is still spending your tokens.
 
 Nothing here needs the mouse. The panel opens with the cursor in the input box; Tab walks both boxes, the dropdown and every button, Enter or space presses whatever is focused, Ctrl+Enter transforms or stops from anywhere, and Escape closes. Bind the panel to a key (see *Installing*) and the whole thing is a keyboard away.
 
-A transformation is just a name and a prompt. The name is what the dropdown shows; the prompt is what the agent is told to do with your text. Press the gear to edit them, add your own, or throw out the ones you never use.
+A transformation is a name, a prompt, and an optional automatic clipboard copy. The name is what the dropdown shows; the prompt is what the agent is told to do with your text. Press the gear to edit them, add your own, or throw out the ones you never use. The copy button beside each prompt is on by default; turn it off for questions whose answers you want to read in the panel without replacing your clipboard.
 
 Three come with it: fix typos, make it shorter, translate to Dutch. That is deliberately not a set of everything you might want; the plugin is worth having because you write the ones you need yourself. "Rewrite this as a commit message", "turn this into English that does not read like a translation", "say this the way I would say it": each of those is a name and a prompt, and then it is a keypress away.
 
@@ -94,7 +94,7 @@ If even that Enter is one key too many, there is also a binding that presses the
 o.bind("SUPER + SHIFT + T", "Transform clipboard now", "omarchy-shell jankeesvw.text-transform transform")
 ```
 
-That runs the last-used transformation on the clipboard the moment you press it, and when the answer has been copied the panel closes itself again: one key, a few seconds, and the result is ready to paste. The panel still opens while it works, so you can see the spinner and stop it, and if something goes wrong it stays open with the error instead of disappearing on you.
+That runs the last-used transformation on the clipboard the moment you press it. When that transformation copies automatically, the panel closes itself again: one key, a few seconds, and the result is ready to paste. If automatic copy is off, it stays open on the answer instead. The panel always opens while it works, so you can see the spinner and stop it, and if something goes wrong it stays open with the error instead of disappearing on you.
 
 And the whole loop in one key, without even the copy and the paste:
 

--- a/bin/text-transform
+++ b/bin/text-transform
@@ -75,15 +75,18 @@ defaults_json() {
 [
   {
     "name": "Fix typos",
-    "prompt": "Correct the spelling, grammar and punctuation. The language of the text never changes: whatever it is written in, it stays in, and no part of it is ever translated. The single exception is a stray word or phrase left behind in another language, which goes into the language the text as a whole is in. Keep the wording and tone as they are: only fix what is actually wrong."
+    "prompt": "Correct the spelling, grammar and punctuation. The language of the text never changes: whatever it is written in, it stays in, and no part of it is ever translated. The single exception is a stray word or phrase left behind in another language, which goes into the language the text as a whole is in. Keep the wording and tone as they are: only fix what is actually wrong.",
+    "autoCopy": true
   },
   {
     "name": "Make it shorter",
-    "prompt": "Rewrite this to be significantly shorter while keeping every point that matters. Same language, same tone."
+    "prompt": "Rewrite this to be significantly shorter while keeping every point that matters. Same language, same tone.",
+    "autoCopy": true
   },
   {
     "name": "Translate to Dutch",
-    "prompt": "Translate this into Dutch that reads as if it was written in Dutch to begin with. Keep the tone and register of the original, but not its sentence structure: rebuild the sentences the way a Dutch speaker would build them, and use the ordinary Dutch word for what is meant rather than the literal translation. Leave names, quotes and technical terms alone. If a part of the text is already Dutch, leave it as it is."
+    "prompt": "Translate this into Dutch that reads as if it was written in Dutch to begin with. Keep the tone and register of the original, but not its sentence structure: rebuild the sentences the way a Dutch speaker would build them, and use the ordinary Dutch word for what is meant rather than the literal translation. Leave names, quotes and technical terms alone. If a part of the text is already Dutch, leave it as it is.",
+    "autoCopy": true
   }
 ]
 JSON
@@ -141,7 +144,8 @@ clean_transformations() {
     [ (if type == "array" then .[] else empty end)
       | select(type == "object")
       | { name: ((.name // "") | tostring | gsub("^\\s+|\\s+$"; "") | .[0:60]),
-          prompt: ((.prompt // "") | tostring | gsub("^\\s+|\\s+$"; "") | .[0:4000]) }
+          prompt: ((.prompt // "") | tostring | gsub("^\\s+|\\s+$"; "") | .[0:4000]),
+          autoCopy: (if .autoCopy == false then false else true end) }
       | select(.name != "" and .prompt != "") ]
   ' 2>/dev/null
 }


### PR DESCRIPTION
## Summary
- Add a per-transformation automatic clipboard-copy preference, enabled by default for backwards compatibility.
- Add a settings control with a clear disabled state; when automatic copy is off, the answer stays in the panel and is included in the completion notification.
- Keep the one-key transform panel open when automatic copy is disabled, and document the behavior.

<img width="1033" height="1033" alt="image" src="https://github.com/user-attachments/assets/d0e7d968-aa8e-473e-9c37-09504dc04f59" />


## Testing
- `bash -n bin/text-transform`
- Verified default, legacy, enabled, and disabled transformation settings round-trip correctly.
- Restarted the Omarchy shell and checked for relevant QML errors.